### PR TITLE
Create the lock object used

### DIFF
--- a/FBAnnotationClustering/FBClusteringManager.m
+++ b/FBAnnotationClustering/FBClusteringManager.m
@@ -64,6 +64,7 @@ CGFloat FBCellSizeForZoomScale(MKZoomScale zoomScale)
 {
     self = [super init];
     if (self) {
+        _lock = [NSRecursiveLock new];
         [self addAnnotations:annotations];
     }
     return self;


### PR DESCRIPTION
Otherwise, the lock will always be nil.