### PR TITLE
Dynamic Clustering

### DIFF
--- a/Example/AnnotationClustering.xcodeproj/project.pbxproj
+++ b/Example/AnnotationClustering.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8A86F1B196A24278AA00E45F /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F00D94D0560465788605775 /* libPods.a */; };
+		A421D4561B4320B000EF0ED2 /* FBAnnotationTwo.m in Sources */ = {isa = PBXBuildFile; fileRef = A421D4551B4320B000EF0ED2 /* FBAnnotationTwo.m */; };
 		DC505A8518F0B505008229F7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC505A8418F0B505008229F7 /* Foundation.framework */; };
 		DC505A8718F0B505008229F7 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC505A8618F0B505008229F7 /* CoreGraphics.framework */; };
 		DC505A8918F0B505008229F7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC505A8818F0B505008229F7 /* UIKit.framework */; };
@@ -39,6 +40,8 @@
 /* Begin PBXFileReference section */
 		07747994D3D1DB6F5D31E65D /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		3F00D94D0560465788605775 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A421D4541B4320B000EF0ED2 /* FBAnnotationTwo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAnnotationTwo.h; sourceTree = "<group>"; };
+		A421D4551B4320B000EF0ED2 /* FBAnnotationTwo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBAnnotationTwo.m; sourceTree = "<group>"; };
 		AD84D55ACD714A4191C3DDAF /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		DC505A8118F0B505008229F7 /* AnnotationClustering.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AnnotationClustering.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC505A8418F0B505008229F7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -204,6 +207,8 @@
 			children = (
 				DC505AC618F0BA9E008229F7 /* FBAnnotation.h */,
 				DC505AC718F0BA9E008229F7 /* FBAnnotation.m */,
+				A421D4541B4320B000EF0ED2 /* FBAnnotationTwo.h */,
+				A421D4551B4320B000EF0ED2 /* FBAnnotationTwo.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -346,6 +351,7 @@
 				DC505AC318F0B9C7008229F7 /* FBAppDelegate.m in Sources */,
 				DC505A9118F0B505008229F7 /* main.m in Sources */,
 				DC505AC418F0B9C7008229F7 /* FBViewController.m in Sources */,
+				A421D4561B4320B000EF0ED2 /* FBAnnotationTwo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Classes/Controllers/FBViewController.m
+++ b/Example/Classes/Controllers/FBViewController.m
@@ -8,6 +8,7 @@
 
 #import "FBViewController.h"
 #import "FBAnnotation.h"
+#import "FBAnnotationTwo.h"
 
 #define kNUMBER_OF_LOCATIONS 1000
 
@@ -29,11 +30,14 @@
 	// Do any additional setup after loading the view, typically from a nib.
 
     NSMutableArray *array = [self randomLocationsWithCount:kNUMBER_OF_LOCATIONS];
+
     self.numberOfLocations = kNUMBER_OF_LOCATIONS;
     [self updateLabelText];
     
     // Create clustering manager
     self.clusteringManager = [[FBClusteringManager alloc] initWithAnnotations:array];
+    [self.clusteringManager registerClass:[FBAnnotation class]];
+    [self.clusteringManager registerClass:[FBAnnotationTwo class]];
     self.clusteringManager.delegate = self;
     
     self.mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 0);
@@ -72,8 +76,11 @@
     if ([annotation isKindOfClass:[FBAnnotationCluster class]]) {
         FBAnnotationCluster *cluster = (FBAnnotationCluster *)annotation;
         cluster.title = [NSString stringWithFormat:@"%lu", (unsigned long)cluster.annotations.count];
-        
-        annotationView.pinColor = MKPinAnnotationColorGreen;
+        if ([cluster.annotClassType isEqual:[FBAnnotation class]]) {
+            annotationView.pinColor = MKPinAnnotationColorPurple;
+        } else {
+            annotationView.pinColor = MKPinAnnotationColorGreen;
+        }
         annotationView.canShowCallout = YES;
     } else {
         annotationView.pinColor = MKPinAnnotationColorRed;
@@ -110,10 +117,15 @@
 {
     NSMutableArray *array = [NSMutableArray array];
     for (int i = 0; i < count; i++) {
-        FBAnnotation *a = [[FBAnnotation alloc] init];
-        a.coordinate = CLLocationCoordinate2DMake(drand48() * 40 - 20, drand48() * 80 - 40);
-        
-        [array addObject:a];
+        if (i % 2 == 0) {
+            FBAnnotation *a = [[FBAnnotation alloc] init];
+            a.coordinate = CLLocationCoordinate2DMake(drand48() * 40 - 20, drand48() * 80 - 40);
+            [array addObject:a];
+        } else {
+            FBAnnotationTwo *a = [[FBAnnotationTwo alloc] init];
+            a.coordinate = CLLocationCoordinate2DMake(drand48() * 40 - 20, drand48() * 80 - 40);
+            [array addObject:a];
+        }
     }
     return array;
 }

--- a/Example/Classes/Models/FBAnnotationTwo.h
+++ b/Example/Classes/Models/FBAnnotationTwo.h
@@ -1,0 +1,16 @@
+//
+//  FBAnnotationTwo.h
+//  AnnotationClustering
+//
+//  Created by Jeff Avery on 2015-06-30.
+//  Copyright (c) 2015 Infinum Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@import MapKit;
+
+@interface FBAnnotationTwo : NSObject <MKAnnotation>
+
+@property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+
+@end

--- a/Example/Classes/Models/FBAnnotationTwo.m
+++ b/Example/Classes/Models/FBAnnotationTwo.m
@@ -1,0 +1,13 @@
+//
+//  FBAnnotationTwo.m
+//  AnnotationClustering
+//
+//  Created by Jeff Avery on 2015-06-30.
+//  Copyright (c) 2015 Infinum Ltd. All rights reserved.
+//
+
+#import "FBAnnotationTwo.h"
+
+@implementation FBAnnotationTwo
+
+@end

--- a/FBAnnotationClustering/FBAnnotationCluster.h
+++ b/FBAnnotationClustering/FBAnnotationCluster.h
@@ -27,4 +27,7 @@
 /// Array of the annotations that are representer with this cluster.
 @property (nonatomic, strong) NSArray *annotations;
 
+// Categorize annotations with a class
+@property (nonatomic, strong) id annotClassType;
+
 @end

--- a/FBAnnotationClustering/FBClusteringManager.h
+++ b/FBAnnotationClustering/FBClusteringManager.h
@@ -42,6 +42,12 @@
  */
 - (id)initWithAnnotations:(NSArray *)annotations;
 
+/**
+ Register an annotation class to be clustered separately from other annotations
+ 
+ @param annotClass register a specific class to be separated when clustering
+ */
+- (void)registerClass:(Class)annotClass;
 
 /**
  Replace current annotations new array of annotations.


### PR DESCRIPTION
**Motivation**
- allow dynamic categorization of clustering given custom annotation classes.

Example: given two different annotations (MyAnnotOne, MyAnnotOne) I want to cluster them _separately_ and consequently display different views. Essentially, I want to be able to have red clusters for something types and blue clusters for others.

**Technical Issues**
- `FBClusteringManager` creates a generic `FBAnnotationCluster` which does not allow `- (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id<MKAnnotation>)annotation` to distinguish one cluster from another
- the clustering logic was impartial to annotation type.

**Changes**
- added `@property (nonatomic, strong) id annotClassType` to `FBAnnotationCluster` to allow delegates of `MKMapView` determine which cluster it receives
- added `- (void)registerClass:(Class)annotClass;` to register annotation classes for separate clustering
- changed logic of `- (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect withZoomScale:(double)zoomScale withFilter:(BOOL (^)(id<MKAnnotation>)) filter` to cluster annotations by registered classes

**Notes**
- if no classes are registered, then this will behave as normal

Feedback would be greatly appreciated!
