### PR TITLE
Fix for Issue #18

### DIFF
--- a/FBAnnotationClustering/FBAnnotationCluster.m
+++ b/FBAnnotationClustering/FBAnnotationCluster.m
@@ -10,12 +10,14 @@
 
 @implementation FBAnnotationCluster
 
-- (NSUInteger)hash {
+- (NSUInteger)hash
+{
     NSString *toHash = [NSString stringWithFormat:@"%.5F%.5F", self.coordinate.latitude, self.coordinate.longitude];
     return [toHash hash];
 }
 
-- (BOOL)isEqual:(id)object {
+- (BOOL)isEqual:(id)object
+{
     return [self hash] == [object hash];
 }
 

--- a/FBAnnotationClustering/FBAnnotationCluster.m
+++ b/FBAnnotationClustering/FBAnnotationCluster.m
@@ -10,4 +10,13 @@
 
 @implementation FBAnnotationCluster
 
+- (NSUInteger)hash {
+    NSString *toHash = [NSString stringWithFormat:@"%.5F%.5F", self.coordinate.latitude, self.coordinate.longitude];
+    return [toHash hash];
+}
+
+- (BOOL)isEqual:(id)object {
+    return [self hash] == [object hash];
+}
+
 @end


### PR DESCRIPTION
This PR fixes that all displayed clustered annotations were always removed and re-added when the mapView's region changed.

I added a custom `hash` for the `FBAnnotationCluster` class and overrode the `isEqual:` method so that two objects are considered equal when their `coordinates` are equal. (I took the cue from the `TBAnnotationClustering` example project.)

This enables the `FBClusteringManager` to keep annotations that did not change their coordinates and only removes annotations that are not on the map anymore.

This fixes the behavior described in issue https://github.com/infinum/FBAnnotationClustering/issues/18
