### PR TITLE
Implemented FBAnnotationCluster hash and isEqual

### DIFF
--- a/FBAnnotationClustering/FBAnnotationCluster.m
+++ b/FBAnnotationClustering/FBAnnotationCluster.m
@@ -10,4 +10,26 @@
 
 @implementation FBAnnotationCluster
 
+- (NSUInteger)hash
+{
+    NSString *toHash = [NSString stringWithFormat:@"%.5F%.5F", self.coordinate.latitude, self.coordinate.longitude];
+    return [toHash hash];
+}
+
+- (BOOL)isEqual:(id)object
+{
+    static const double kSmallValue = 1e-5;
+    
+    if (self == object) {
+        return YES;
+    } else if (![object isKindOfClass:[FBAnnotationCluster class]]) {
+        return NO;
+    } else {
+        FBAnnotationCluster *cluster = object;
+        return self.annotations.count == cluster.annotations.count &&
+               ABS(self.coordinate.latitude - cluster.coordinate.latitude) < kSmallValue &&
+               ABS(self.coordinate.longitude - cluster.coordinate.longitude) < kSmallValue;
+    }
+}
+
 @end


### PR DESCRIPTION
This change is to prevent the unnecessary removal and readding of cluster annotations when the map region changes, but the clusters annotations don't.
