### PR TITLE
Use small cellSize when at zoom level 20 in FBCellSizeForZoomScale

### DIFF
--- a/FBAnnotationClustering/FBClusteringManager.m
+++ b/FBAnnotationClustering/FBClusteringManager.m
@@ -36,6 +36,7 @@ CGFloat FBCellSizeForZoomScale(MKZoomScale zoomScale)
         case 18:
             return 32;
         case 19:
+        case 20:
             return 16;
             
         default:


### PR DESCRIPTION
This fixes a bug where zooming all the way in resulted in major clustering. This is because in FBCellSizeForZoomScale, zoom level 20 wasn't supported, resulting in the default cellSize of 88 being used.
