### PR TITLE
Podfile: specify target

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,2 +1,3 @@
-pod "FBAnnotationClustering", :path => "../FBAnnotationClustering.podspec"
-
+target "AnnotationClustering" do
+	pod "FBAnnotationClustering", :path => "../FBAnnotationClustering.podspec"
+end


### PR DESCRIPTION
targeting this issue -> [Cocoapods: the dependency 'FBAnnotationClustering' is not used in any concrete target](https://github.com/infinum/FBAnnotationClustering/issues/33)