### PR TITLE
Have a minimum amount of annotations to cluster

### DIFF
--- a/FBAnnotationClustering/FBClusteringManager.h
+++ b/FBAnnotationClustering/FBClusteringManager.h
@@ -22,6 +22,14 @@
  */
 - (CGFloat)cellSizeFactorForCoordinator:(FBClusteringManager *)coordinator;
 
+/**
+ Method that allows you to define a minimum number of annotations to cluster.
+ @param coordinator An instance of FBClusterManager.
+ 
+ @discussion The default minimum number of Annotations to cluster is 2. If you don't want to have clusters with with only 2 annotations, you can change it with this method.
+ */
+- (NSUInteger)minAnnotationsNumberToCluster:(FBClusteringManager *)coordinator;
+
 @end
 
 

--- a/FBAnnotationClustering/FBClusteringManager.m
+++ b/FBAnnotationClustering/FBClusteringManager.m
@@ -144,11 +144,17 @@ CGFloat FBCellSizeForZoomScale(MKZoomScale zoomScale)
             }];
             
             NSInteger count = [annotations count];
-            if (count == 1) {
-                [clusteredAnnotations addObjectsFromArray:annotations];
+            NSUInteger minCount = 2;
+            if ([self.delegate respondsToSelector:@selector(minAnnotationsNumberToCluster:)]) {
+                NSUInteger userMinCounter = [self.delegate minAnnotationsNumberToCluster:self];
+                if (userMinCounter > 2) {
+                    minCount = userMinCounter;
+                }
             }
             
-            if (count > 1) {
+            if (count < minCount) {
+                [clusteredAnnotations addObjectsFromArray:annotations];
+            } else {
                 CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(totalLatitude/count, totalLongitude/count);
                 FBAnnotationCluster *cluster = [[FBAnnotationCluster alloc] init];
                 cluster.coordinate = coordinate;


### PR DESCRIPTION
I wanted to have a minimum amount of annotations before the cluster was created. This change allows the developer to specify this value.
