### PR TITLE
Added clustering on minimum amount of annotations capability

### DIFF
--- a/FBAnnotationClustering/FBClusteringManager.h
+++ b/FBAnnotationClustering/FBClusteringManager.h
@@ -72,6 +72,7 @@
  
  @param rect An instance of MKMapRect.
  @param zoomScale An instance of MKMapRect.
+ @param minimum Sets minimum amount of annotations to cluster.
  @returns Array of annotations objects of type @c FBAnnotationCluster or your custom class.
  */
 - (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect
@@ -79,7 +80,12 @@
 
 - (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect
                                  withZoomScale:(double)zoomScale
-                                 withFilter:(BOOL (^)(id<MKAnnotation>)) filter;
+                                   withMinimum:(int)minimum;
+
+- (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect
+                                 withZoomScale:(double)zoomScale
+                                    withFilter:(BOOL (^)(id<MKAnnotation>))filter
+                                   withMinimum:(int)minimum;
 
 /**
  All annotations in quad tree.

--- a/FBAnnotationClustering/FBClusteringManager.m
+++ b/FBAnnotationClustering/FBClusteringManager.m
@@ -104,10 +104,15 @@ CGFloat FBCellSizeForZoomScale(MKZoomScale zoomScale)
 
 - (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect withZoomScale:(double)zoomScale
 {
-    return [self clusteredAnnotationsWithinMapRect:rect withZoomScale:zoomScale withFilter:nil];
+    return [self clusteredAnnotationsWithinMapRect:rect withZoomScale:zoomScale withFilter:nil withMinimum:1];
 }
 
-- (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect withZoomScale:(double)zoomScale withFilter:(BOOL (^)(id<MKAnnotation>)) filter
+- (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect withZoomScale:(double)zoomScale withMinimum:(int)minimum
+{
+    return [self clusteredAnnotationsWithinMapRect:rect withZoomScale:zoomScale withFilter:nil withMinimum:minimum];
+}
+
+- (NSArray *)clusteredAnnotationsWithinMapRect:(MKMapRect)rect withZoomScale:(double)zoomScale withFilter:(BOOL (^)(id<MKAnnotation>))filter withMinimum:(int)minimum
 {
     double cellSize = FBCellSizeForZoomScale(zoomScale);
     if ([self.delegate respondsToSelector:@selector(cellSizeFactorForCoordinator:)]) {
@@ -144,11 +149,9 @@ CGFloat FBCellSizeForZoomScale(MKZoomScale zoomScale)
             }];
             
             NSInteger count = [annotations count];
-            if (count == 1) {
+            if (count <= minimum) {
                 [clusteredAnnotations addObjectsFromArray:annotations];
-            }
-            
-            if (count > 1) {
+            } else {
                 CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(totalLatitude/count, totalLongitude/count);
                 FBAnnotationCluster *cluster = [[FBAnnotationCluster alloc] init];
                 cluster.coordinate = coordinate;


### PR DESCRIPTION
Overload for clusteredAnnotationsWithinMapRect that allows to have a minimum amount of annotations in an area before clustering.